### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description

This PR adds the missing **GitHub Skills** extracurricular activity that was announced by the principal in the school assembly.

## Changes Made

- ✅ Added new "GitHub Skills" activity to the activities database
- ✅ Set schedule: Mondays and Wednesdays, 3:30 PM - 5:00 PM
- ✅ Max participants: 25 students
- ✅ Description includes mention of GitHub Certifications program
- ✅ Description highlights college application benefits

## Issue Context

Fixes #6 

**Why this is urgent:**
- The principal announced this activity in yesterday's school assembly
- Many students are eager to join
- Registration closes by the end of this week
- This is part of our GitHub Certifications program to help with college applications

## Type of change

- [x] New feature
- [x] Bug fix (missing activity is technically a bug)

## Testing

- [x] Python syntax validated (no compilation errors)
- [x] Activity structure matches existing activities format
- [x] Activity will be visible in the activities list
- [x] Students will be able to sign up through the website

## Student Impact

This change will immediately allow students like Hewbie C. (11th Grade) who reported the issue to register for the GitHub Skills activity before the registration deadline.